### PR TITLE
Remove WagmiConfig import from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install use-wagmi viem
 Connect a wallet in under 60 seconds.
 
 ```ts
-import { UseWagmiPlugin, WagmiConfig, createConfig, mainnet } from 'use-wagmi'
+import { UseWagmiPlugin, createConfig, mainnet } from 'use-wagmi'
 import { createPublicClient, http } from 'viem'
 import App from './App.vue'
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -35,7 +35,7 @@ npm install use-wagmi viem
 Connect a wallet in under 60 seconds.
 
 ```ts
-import { UseWagmiPlugin, WagmiConfig, createConfig, mainnet } from 'use-wagmi'
+import { UseWagmiPlugin, createConfig, mainnet } from 'use-wagmi'
 import { createPublicClient, http } from 'viem'
 import App from './App.vue'
 


### PR DESCRIPTION
WagmiConfig is not exported by the latest version of use-wagmi, and is not used in the example code. Previous example code would throw an error when run.