### PR TITLE
feat: create vue providable config

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,7 +1,7 @@
 export { createConfig } from './config'
 export type { Config, CreateConfigParameters } from './config'
 
-export { UseWagmiPlugin, useConfig } from './plugin'
+export { UseWagmiPlugin, createVueProvidableConfig, useConfig } from './plugin'
 
 export {
   paginatedIndexesConfig,


### PR DESCRIPTION
This PR extracts a `createVueProvidableConfig` utility to make it easier for 3rd party integrations to use this library without relying on `UseWagmiPlugin`. For example this is desirable for direct integration with [`vue-query-nuxt`](https://github.com/Hebilicious/vue-query-nuxt/blob/main/playgrounds/wagmi/vue-query.config.ts).