### PR TITLE
feat(nuxt): add excludeImports

### DIFF
--- a/.changeset/giant-wombats-add.md
+++ b/.changeset/giant-wombats-add.md
@@ -1,0 +1,5 @@
+---
+'@use-wagmi/nuxt': patch
+---
+
+add excludeImports

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -9,6 +9,10 @@ export interface WagmiNuxtOptions {
    * @default true
    */
   autoImports?: boolean
+  /**
+   * List of imports to exclude from auto-imports
+   */
+  excludeImports?: string[]
 }
 
 export default defineNuxtModule<WagmiNuxtOptions>({
@@ -17,11 +21,12 @@ export default defineNuxtModule<WagmiNuxtOptions>({
     configKey: packageName,
     compatibility: {
       nuxt: '^3.0.0 || ^2.16.0',
-      bridge: true
-    }
+      bridge: true,
+    },
   },
   defaults: {
     autoImports: true,
+    excludeImports: [],
   },
   setup(options, nuxt) {
     // add packages to transpile target for alias resolution
@@ -29,17 +34,19 @@ export default defineNuxtModule<WagmiNuxtOptions>({
     nuxt.options.build.transpile = nuxt.options.build.transpile || []
     nuxt.options.build.transpile.push(packageName)
 
+    const exclude = nuxt.options.wagmi?.excludeImports || []
     if (options.autoImports) {
       nuxt.hook('imports:sources', (sources) => {
         if (sources.find((i) => i.from === packageName)) return
 
         const imports = Object.keys(functions)
           .filter((name) => !gitignore.includes(name))
-          .map((i) => {
+          .filter((name) => !exclude.includes(name))
+          .map((name) => {
             return {
               from: packageName,
-              name: i,
-              as: i,
+              name,
+              as: name,
               priority: -1,
             }
           })


### PR DESCRIPTION
This adds a setting that can disable some auto-imports. This is useful when some auto-imports have conflicting names with existing composable, or when an integration wants to provide a custom auto-import to replace the default one.