### PR TITLE
fix: remove 'use client' directive from src/hooks

### DIFF
--- a/packages/vue/src/hooks/useAccount.ts
+++ b/packages/vue/src/hooks/useAccount.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetAccountReturnType,

--- a/packages/vue/src/hooks/useAccountEffect.ts
+++ b/packages/vue/src/hooks/useAccountEffect.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { type GetAccountReturnType, watchAccount } from '@wagmi/core'
 import type { Evaluate } from '@wagmi/core/internal'
 import { unref, watchEffect } from 'vue-demi'

--- a/packages/vue/src/hooks/useBalance.ts
+++ b/packages/vue/src/hooks/useBalance.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetBalanceErrorType,

--- a/packages/vue/src/hooks/useBlock.ts
+++ b/packages/vue/src/hooks/useBlock.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQueryClient } from '@tanstack/vue-query'
 import {
   type Config,

--- a/packages/vue/src/hooks/useBlockNumber.ts
+++ b/packages/vue/src/hooks/useBlockNumber.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQueryClient } from '@tanstack/vue-query'
 import {
   type Config,

--- a/packages/vue/src/hooks/useBlockTransactionCount.ts
+++ b/packages/vue/src/hooks/useBlockTransactionCount.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetBlockTransactionCountErrorType,

--- a/packages/vue/src/hooks/useBytecode.ts
+++ b/packages/vue/src/hooks/useBytecode.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetBytecodeErrorType,

--- a/packages/vue/src/hooks/useCall.ts
+++ b/packages/vue/src/hooks/useCall.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type CallErrorType,
   type Config,

--- a/packages/vue/src/hooks/useChainId.ts
+++ b/packages/vue/src/hooks/useChainId.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetChainIdReturnType,

--- a/packages/vue/src/hooks/useChains.ts
+++ b/packages/vue/src/hooks/useChains.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetChainsReturnType,
@@ -27,9 +25,9 @@ export function useChains<config extends Config = ResolvedRegister['config']>(
   const chains = ref(getChains(config))
 
   watchChains(config, {
-    onChange () {
+    onChange() {
       chains.value = getChains(config)
-    }
+    },
   })
 
   return chains

--- a/packages/vue/src/hooks/useClient.ts
+++ b/packages/vue/src/hooks/useClient.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetClientParameters,

--- a/packages/vue/src/hooks/useConfig.ts
+++ b/packages/vue/src/hooks/useConfig.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { type Config, type ResolvedRegister } from '@wagmi/core'
 import { inject, unref } from 'vue-demi'
 

--- a/packages/vue/src/hooks/useConnect.ts
+++ b/packages/vue/src/hooks/useConnect.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useMutation } from '@tanstack/vue-query'
 import {
   type Config,

--- a/packages/vue/src/hooks/useConnections.ts
+++ b/packages/vue/src/hooks/useConnections.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type GetConnectionsReturnType,
   getConnections,

--- a/packages/vue/src/hooks/useConnectorClient.ts
+++ b/packages/vue/src/hooks/useConnectorClient.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useQueryClient } from '@tanstack/vue-query'
 import type {
   Config,

--- a/packages/vue/src/hooks/useConnectors.ts
+++ b/packages/vue/src/hooks/useConnectors.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type GetConnectorsReturnType,
   getConnectors,

--- a/packages/vue/src/hooks/useDisconnect.ts
+++ b/packages/vue/src/hooks/useDisconnect.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useMutation } from '@tanstack/vue-query'
 import { type Connector, type DisconnectErrorType } from '@wagmi/core'
 import type { Evaluate } from '@wagmi/core/internal'
@@ -63,7 +61,9 @@ export function useDisconnect<context = unknown>(
   return {
     ...result,
     connectors: computed(() =>
-      useConnections({ config }).value.map((connection) => connection.connector),
+      useConnections({ config }).value.map(
+        (connection) => connection.connector,
+      ),
     ),
     disconnect: mutate,
     disconnectAsync: mutateAsync,

--- a/packages/vue/src/hooks/useEnsAddress.ts
+++ b/packages/vue/src/hooks/useEnsAddress.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type {
   Config,
   GetEnsAddressErrorType,

--- a/packages/vue/src/hooks/useEnsAvatar.ts
+++ b/packages/vue/src/hooks/useEnsAvatar.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type {
   Config,
   GetEnsAvatarErrorType,

--- a/packages/vue/src/hooks/useEnsName.ts
+++ b/packages/vue/src/hooks/useEnsName.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type { Config, GetEnsNameErrorType, ResolvedRegister } from '@wagmi/core'
 import { type Evaluate } from '@wagmi/core/internal'
 import {

--- a/packages/vue/src/hooks/useEnsResolver.ts
+++ b/packages/vue/src/hooks/useEnsResolver.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type {
   Config,
   GetEnsResolverErrorType,

--- a/packages/vue/src/hooks/useEnsText.ts
+++ b/packages/vue/src/hooks/useEnsText.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type { Config, GetEnsTextErrorType, ResolvedRegister } from '@wagmi/core'
 import { type Evaluate } from '@wagmi/core/internal'
 import {

--- a/packages/vue/src/hooks/useEstimateFeesPerGas.ts
+++ b/packages/vue/src/hooks/useEstimateFeesPerGas.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type EstimateFeesPerGasErrorType,

--- a/packages/vue/src/hooks/useEstimateGas.ts
+++ b/packages/vue/src/hooks/useEstimateGas.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type {
   Config,
   Connector,

--- a/packages/vue/src/hooks/useEstimateMaxPriorityFeePerGas.ts
+++ b/packages/vue/src/hooks/useEstimateMaxPriorityFeePerGas.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type EstimateMaxPriorityFeePerGasErrorType,

--- a/packages/vue/src/hooks/useFeeHistory.ts
+++ b/packages/vue/src/hooks/useFeeHistory.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetFeeHistoryErrorType,

--- a/packages/vue/src/hooks/useGasPrice.ts
+++ b/packages/vue/src/hooks/useGasPrice.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetGasPriceErrorType,

--- a/packages/vue/src/hooks/useInfiniteReadContracts.ts
+++ b/packages/vue/src/hooks/useInfiniteReadContracts.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type {
   Config,
   ReadContractsErrorType,

--- a/packages/vue/src/hooks/usePrepareTransactionRequest.ts
+++ b/packages/vue/src/hooks/usePrepareTransactionRequest.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type PrepareTransactionRequestErrorType,

--- a/packages/vue/src/hooks/useProof.ts
+++ b/packages/vue/src/hooks/useProof.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetProofErrorType,

--- a/packages/vue/src/hooks/usePublicClient.ts
+++ b/packages/vue/src/hooks/usePublicClient.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetPublicClientParameters,

--- a/packages/vue/src/hooks/useReadContract.ts
+++ b/packages/vue/src/hooks/useReadContract.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type ReadContractErrorType,

--- a/packages/vue/src/hooks/useReadContracts.ts
+++ b/packages/vue/src/hooks/useReadContracts.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type ReadContractsErrorType,

--- a/packages/vue/src/hooks/useReconnect.ts
+++ b/packages/vue/src/hooks/useReconnect.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useMutation } from '@tanstack/vue-query'
 import { type Connector, type ReconnectErrorType } from '@wagmi/core'
 import type { Evaluate } from '@wagmi/core/internal'

--- a/packages/vue/src/hooks/useSendTransaction.ts
+++ b/packages/vue/src/hooks/useSendTransaction.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useMutation } from '@tanstack/vue-query'
 import type {
   Config,

--- a/packages/vue/src/hooks/useSignMessage.ts
+++ b/packages/vue/src/hooks/useSignMessage.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useMutation } from '@tanstack/vue-query'
 import { type SignMessageErrorType } from '@wagmi/core'
 import type { Evaluate } from '@wagmi/core/internal'

--- a/packages/vue/src/hooks/useSignTypedData.ts
+++ b/packages/vue/src/hooks/useSignTypedData.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useMutation } from '@tanstack/vue-query'
 import type { SignTypedDataErrorType } from '@wagmi/core'
 import type { Evaluate } from '@wagmi/core/internal'

--- a/packages/vue/src/hooks/useSimulateContract.ts
+++ b/packages/vue/src/hooks/useSimulateContract.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type {
   Config,
   ResolvedRegister,

--- a/packages/vue/src/hooks/useStorageAt.ts
+++ b/packages/vue/src/hooks/useStorageAt.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetStorageAtErrorType,

--- a/packages/vue/src/hooks/useSwitchAccount.ts
+++ b/packages/vue/src/hooks/useSwitchAccount.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useMutation } from '@tanstack/vue-query'
 import {
   type Config,
@@ -77,7 +75,9 @@ export function useSwitchAccount<
   return {
     ...result,
     connectors: computed(() =>
-      useConnections({ config }).value.map((connection) => connection.connector),
+      useConnections({ config }).value.map(
+        (connection) => connection.connector,
+      ),
     ),
     switchAccount: mutate,
     switchAccountAsync: mutateAsync,

--- a/packages/vue/src/hooks/useSwitchChain.ts
+++ b/packages/vue/src/hooks/useSwitchChain.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useMutation } from '@tanstack/vue-query'
 import type {
   Config,

--- a/packages/vue/src/hooks/useToken.ts
+++ b/packages/vue/src/hooks/useToken.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type { Config, GetTokenErrorType, ResolvedRegister } from '@wagmi/core'
 import { type Evaluate } from '@wagmi/core/internal'
 import {

--- a/packages/vue/src/hooks/useTransaction.ts
+++ b/packages/vue/src/hooks/useTransaction.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type {
   Config,
   GetTransactionErrorType,

--- a/packages/vue/src/hooks/useTransactionConfirmations.ts
+++ b/packages/vue/src/hooks/useTransactionConfirmations.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetTransactionConfirmationsErrorType,

--- a/packages/vue/src/hooks/useTransactionCount.ts
+++ b/packages/vue/src/hooks/useTransactionCount.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetTransactionCountErrorType,

--- a/packages/vue/src/hooks/useTransactionReceipt.ts
+++ b/packages/vue/src/hooks/useTransactionReceipt.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type GetTransactionReceiptErrorType,

--- a/packages/vue/src/hooks/useVerifyMessage.ts
+++ b/packages/vue/src/hooks/useVerifyMessage.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type ResolvedRegister,

--- a/packages/vue/src/hooks/useVerifyTypedData.ts
+++ b/packages/vue/src/hooks/useVerifyTypedData.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type ResolvedRegister,

--- a/packages/vue/src/hooks/useWaitForTransactionReceipt.ts
+++ b/packages/vue/src/hooks/useWaitForTransactionReceipt.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type {
   Config,
   ResolvedRegister,

--- a/packages/vue/src/hooks/useWalletClient.ts
+++ b/packages/vue/src/hooks/useWalletClient.ts
@@ -1,5 +1,3 @@
-'use client'
-
 // Almost identical implementation to `useConnectorClient` (except for return type)
 // Should update both in tandem
 

--- a/packages/vue/src/hooks/useWatchBlockNumber.ts
+++ b/packages/vue/src/hooks/useWatchBlockNumber.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type ResolvedRegister,

--- a/packages/vue/src/hooks/useWatchBlocks.ts
+++ b/packages/vue/src/hooks/useWatchBlocks.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type ResolvedRegister,

--- a/packages/vue/src/hooks/useWatchContractEvent.ts
+++ b/packages/vue/src/hooks/useWatchContractEvent.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type ResolvedRegister,

--- a/packages/vue/src/hooks/useWatchPendingTransactions.ts
+++ b/packages/vue/src/hooks/useWatchPendingTransactions.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type Config,
   type ResolvedRegister,

--- a/packages/vue/src/hooks/useWriteContract.ts
+++ b/packages/vue/src/hooks/useWriteContract.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useMutation } from '@tanstack/vue-query'
 import type {
   Config,


### PR DESCRIPTION
All `src/hooks/**` modules include the react "use client" directive on top of the file, causing vite build to display warning messages when bundling for production.

`...useAccount.js (1:0) Module level directives cause errors when bundled, "use client" in ... was ignored.`

etc.

This PR removes them.

Note: running biome after the fix has also added a few missing trailing commas (according to biome.json config) in several hooks: `useChains`, `useDisconnect` and `useSwitchAccount`.